### PR TITLE
change drone to only build and publish on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,6 @@ steps:
       - '2019.2.0-amd64'
   when:
     event:
-    - push
     - tag
 
 ---
@@ -47,8 +46,8 @@ steps:
       - '2019.2.0-arm64'
   when:
     event:
-    - push
     - tag
+
 ---
 kind: pipeline
 name: linux-arm
@@ -72,7 +71,6 @@ steps:
       - '2019.2.0-arm'
   when:
     event:
-    - push
     - tag
 
 ---
@@ -95,7 +93,6 @@ steps:
       from_secret: docker_username
   when:
     event:
-    - push
     - tag
 depends_on:
   - linux-arm


### PR DESCRIPTION
## Purpose
Drone builds on every push, causing the queue to fill up.

## Overview
Drone doesn't seem to have the ability to tag by commit hash /shrug

## Impact
Only build on tag

## Rollback
Revert commit
